### PR TITLE
Add Pasta Mensa Selectors

### DIFF
--- a/utils/constants.py
+++ b/utils/constants.py
@@ -37,17 +37,25 @@ class Urls:
 
 
 class MensaSelectors:
-    # --- Common CSS selectors used for all meal types ---
-    # All Selectors are relative to the MEAL_CONTAINER, including the MEAL_CONTAINER itself
-    MEAL_CONTAINER = "main#page-content > div.grid-container > div > div > div:nth-of-type(3) > div"
-    MEAL_TYPE = "div:nth-of-type(1) > div:nth-of-type(1)"
-    MEAL_PRICE = "div:nth-of-type(3) > div:nth-of-type(1)"
-    # Specific selectors for meal details which are not pasta
-    MEAL_NAME = "h4"
-    MEAL_COMPONENTS = "h4 + div"
-    # Specific selector for pasta meal type
-    PASTA_SUBITEM = ".meal-subitem"
-    PASTA_NAME = "h5"
+
+    class Common:
+        # --- Common CSS selectors used for all meal types ---
+        # All Selectors are relative to the MEAL_CONTAINER, including the MEAL_CONTAINER itself
+        MEAL_CONTAINER = "main#page-content > div.grid-container > div > div > div:nth-of-type(3) > div"
+        MEAL_TYPE = "div:nth-of-type(1) > div:nth-of-type(1)"
+
+    class Normal:
+        # Specific selectors for meal details which are not pasta
+        MEAL_PRICE = "div:nth-of-type(3) > div:nth-of-type(1)"
+        MEAL_NAME = "h4"
+        MEAL_COMPONENTS = "h4 + div"
+
+    class Pasta:
+        # Specific selector for pasta meal type
+        PRICE = "div:nth-of-type(2) > div:nth-of-type(1)"
+        SUBITEMS = "div[hidden] > div"
+        NAME = "h4"
+        COMPONENTS = "h5"
 
 
 class AI:

--- a/utils/mensaUtils.py
+++ b/utils/mensaUtils.py
@@ -92,8 +92,8 @@ def extract_standard_meal_data(
         MensaSelectors.Normal.MEAL_COMPONENTS
     )
 
-    if not name_element:
-        return None
+    if not name_element or not price_element:
+        return
 
     name = name_element.text
 


### PR DESCRIPTION
This pull request refactors the code for extracting meal data from the Mensa website to improve maintainability and clarity. The main changes include reorganizing CSS selectors into themed groups, updating extraction logic for both standard and pasta meals, and renaming functions for consistency.

**Selectors refactoring:**

* Grouped CSS selectors in `MensaSelectors` into `Common`, `Normal`, and `Pasta` classes in `utils/constants.py`, making it easier to manage and extend selectors for different meal types.

**Extraction logic improvements:**

* Updated the main extraction loop in `get_mensa_plan` to use the new selector structure and refactored logic to distinguish between standard and pasta meals more clearly.
* Refactored `extract_standard_meal_data` to use selectors from `MensaSelectors.Normal` and streamlined component and price extraction.
* Overhauled `extract_pasta_meal_data` to use selectors from `MensaSelectors.Pasta`, extract price and components for each subitem, and yield multiple meals if present.

**Function naming consistency:**

* Renamed `retrieve_standard_meal_data` to `extract_standard_meal_data` for consistency with the pasta meal extraction function.