### PR TITLE
Fix devcontainer not initializing the db file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,7 +20,3 @@ RUN pip install --no-cache-dir -r development.requirements.txt
 # Install main requirements
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-
-# Initialize data directory
-RUN mkdir ./data
-RUN touch ./data/db.sqlite3

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,5 +21,5 @@
       ]
     }
   },
-  "postCreateCommand": "aerich upgrade"
+  "postCreateCommand": "mkdir -p data && touch data/db.sqlite3 && aerich upgrade"
 }


### PR DESCRIPTION
This pull request updates the devcontainer setup to ensure the `data` directory and `db.sqlite3` file are properly initialized during container creation, moving this logic from the Dockerfile to the `devcontainer.json` configuration.

Devcontainer setup improvements:

* Moved the creation of the `data` directory and `db.sqlite3` file from `.devcontainer/Dockerfile` to the `postCreateCommand` in `.devcontainer/devcontainer.json`, ensuring these are set up after the container is built. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6L23-L26) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L24-R24)