### PR TITLE
feat.✨: instant quote

### DIFF
--- a/cogs/quoteService.py
+++ b/cogs/quoteService.py
@@ -198,7 +198,7 @@ class QuoteService(commands.Cog):
         await self._store_and_send_quote(ctx, [message], None)
 
         await ctx.respond(
-            f"📌 Nachricht von **{message.author.display_name}** im Quotes-Channel zitiert!\n",
+            f"📌 Nachricht von **{message.author.display_name}** im Quotes-Channel zitiert!",
             ephemeral=True
         )
 


### PR DESCRIPTION
Adds the message command "Quote" that immediately uses `quoteUtils.send_embed()` to quote the selected message into the quotes channel.

This is wanted because it's a quicker and simpler pipeline for quick quoting rather than having to first select the message(s) and then use a different command to send them.