### PR TITLE
Improve timeout and caching of timetable

### DIFF
--- a/src/cogs/timetableService.py
+++ b/src/cogs/timetableService.py
@@ -29,12 +29,14 @@ class TimetableService(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         """
-        Warm cache and start background refresh when bot is ready.
+        Warm cache when bot is ready.
         """
 
         # warm cache - currently, it always fetches all days anyway
-        # if campus dual should offer a proper API some day (LOL) this magic number will allow users to have 30 days pre-cached
-        _ = timetableUtils.get_timetable(30)
+        # if campus dual should offer a proper API someday (LOL) this would actually have an effect
+        _ = asyncio.create_task(
+            asyncio.to_thread(timetableUtils.get_timetable, MAX_TIMETABLE_RANGE_DAYS)
+        )
 
         if not self.send_daily_timetable.is_running():
             self.send_daily_timetable.start()

--- a/src/cogs/timetableService.py
+++ b/src/cogs/timetableService.py
@@ -16,7 +16,7 @@ from utils.timetableUtils import MAX_TIMETABLE_RANGE_DAYS
 
 class TimetableService(commands.Cog):
     """A Discord cog that provides commands to view the class timetable.
-    
+
     This cog allows users to fetch and display class schedules for different time periods
     using slash commands. It integrates with the Campus Dual system to provide up-to-date
     timetable information.
@@ -31,8 +31,10 @@ class TimetableService(commands.Cog):
         """
         Warm cache and start background refresh when bot is ready.
         """
-        if not self.refresh_timetable_cache.is_running():
-            self.refresh_timetable_cache.start()
+
+        # warm cache - currently, it always fetches all days anyway
+        # if campus dual should offer a proper API some day (LOL) this magic number will allow users to have 30 days pre-cached
+        _ = timetableUtils.get_timetable(30)
 
         if not self.send_daily_timetable.is_running():
             self.send_daily_timetable.start()
@@ -41,18 +43,16 @@ class TimetableService(commands.Cog):
 
     @commands.slash_command(
         name="timetable",
-        description=
-        "Sieh dir den Stundenplan für `today`, `tomorrow` oder die nächsten `n` Tage an",
-        guild_ids=[Constants.SERVER_IDS.CUR_SERVER]
+        description="Sieh dir den Stundenplan für `today`, `tomorrow` oder die nächsten `n` Tage an",
+        guild_ids=[Constants.SERVER_IDS.CUR_SERVER],
     )
     @discord.option(
         name="days",
         type=SlashCommandOptionType.string,
-        description=
-        f"`today`, `tomorrow`, oder eine Zahl (1-{MAX_TIMETABLE_RANGE_DAYS}). Standard ist 7, d.h. der Plan für die nächsten 7 Tage.",
+        description=f"`today`, `tomorrow`, oder eine Zahl (1-{MAX_TIMETABLE_RANGE_DAYS}). Standard ist 7, d.h. der Plan für die nächsten 7 Tage.",
         required=False,
         default="7",
-        autocomplete=basic_autocomplete(timetableUtils.days_autocomplete)
+        autocomplete=basic_autocomplete(timetableUtils.days_autocomplete),
     )
     async def timetable(self, ctx: ApplicationContext, days: str):
         """Fetch and display the class timetable.
@@ -110,22 +110,11 @@ class TimetableService(commands.Cog):
         timetable_text = timetableUtils.get_timetable(days=0)
         await self.send_long_message(channel, timetable_text)
 
-    @tasks.loop(minutes=60)
-    async def refresh_timetable_cache(self):
-        """Periodically refresh Campus Dual cache in background every 60 minutes."""
-        await asyncio.to_thread(
-            timetableUtils.warm_timetable_cache,
-            True  # do force refresh
-        )
-        self.logger.info("Timetable cache refreshed successfully")
-
     async def send_long_message(
-        self,
-        target: ApplicationContext | Messageable,
-        text: str
+        self, target: ApplicationContext | Messageable, text: str
     ) -> None:
         """Split messages into 2000-character chunks."""
-        chunks = [text[i:i + 2000] for i in range(0, len(text), 2000)]
+        chunks = [text[i : i + 2000] for i in range(0, len(text), 2000)]
         for i, chunk in enumerate(chunks):
             if isinstance(target, ApplicationContext):
                 if i == 0:

--- a/src/utils/timetableUtils.py
+++ b/src/utils/timetableUtils.py
@@ -11,7 +11,8 @@ from utils.constants import Constants
 
 _SESSION = CachedSession(
     backend="memory",
-    stale_while_revalidate=timedelta(hours=24),
+    expire_after=timedelta(hours=24),
+    stale_while_revalidate=True,
 )
 """Cache session for campus API"""
 
@@ -88,7 +89,9 @@ def _fetch_timetable_entries(force_refresh: bool = False) -> list[TimetableEntry
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", InsecureRequestWarning)
             response = _SESSION.get(
-                url, verify=False, timeout=None, force_refresh=force_refresh
+                url, verify=False, 
+                timeout=3 * 60, # I fear the day when 3 minutes will be too short
+                force_refresh=force_refresh
             )
         if response.status_code != 200:
             return (

--- a/src/utils/timetableUtils.py
+++ b/src/utils/timetableUtils.py
@@ -11,7 +11,7 @@ from utils.constants import Constants
 
 _SESSION = CachedSession(
     backend="memory",
-    expire_after=45 * 60,  # 45 minutes
+    stale_while_revalidate=timedelta(hours=24),
 )
 """Cache session for campus API"""
 
@@ -81,19 +81,14 @@ def _format_entries(grouped_days: dict[str, list[TimetableEntry]]) -> str:
     return output.strip()
 
 
-def _fetch_timetable_entries(
-    force_refresh: bool = False
-) -> list[TimetableEntry] | str:
+def _fetch_timetable_entries(force_refresh: bool = False) -> list[TimetableEntry] | str:
     """Fetch raw timetable JSON entries or return an error message."""
     url = _campus_url()
     try:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", InsecureRequestWarning)
             response = _SESSION.get(
-                url,
-                verify=False,
-                timeout=15,
-                force_refresh=force_refresh
+                url, verify=False, timeout=None, force_refresh=force_refresh
             )
         if response.status_code != 200:
             return (
@@ -108,30 +103,28 @@ def _fetch_timetable_entries(
                 "❌ Leere Antwort vom Server. "
                 "Mögliche Ursache: ungültiger CAMPUS_USER oder CAMPUS_HASH."
             )
-    except RequestException as ex:
-        return f"❌ Fehler beim Abrufen des Stundenplans: {ex}"
     except JSONDecodeError:
         return "❌ Ungültige JSON-Antwort des Servers."
+    except RequestException as ex:
+        return f"❌ Fehler beim Abrufen des Stundenplans: {ex}"
 
     return entries
 
 
 def _filter_entries_for_window(
-    entries: list[TimetableEntry],
-    start_date: datetime,
-    period_end: datetime
+    entries: list[TimetableEntry], start_date: datetime, period_end: datetime
 ) -> list[TimetableEntry]:
     """Return entries whose start timestamp lies within [start_date, period_end)."""
     return [
-        entry for entry in entries if start_date <=
-        _local_datetime_from_utc_timestamp(entry["start"]) < period_end
+        entry
+        for entry in entries
+        if start_date <= _local_datetime_from_utc_timestamp(entry["start"]) < period_end
     ]
 
 
 def _group_entries_by_date(
-    entries: list[TimetableEntry]
-) -> dict[str,
-          list[TimetableEntry]]:
+    entries: list[TimetableEntry],
+) -> dict[str, list[TimetableEntry]]:
     """Group entries by localized date string."""
     grouped: dict[str, list[TimetableEntry]] = {}
     for entry in entries:
@@ -151,8 +144,7 @@ def _empty_message(days: int) -> str:
 
 def _header(days: int) -> str:
     scope = (
-        "heute"
-        if days == 0 else "morgen" if days == 1 else f"die nächsten {days} Tage"
+        "heute" if days == 0 else "morgen" if days == 1 else f"die nächsten {days} Tage"
     )
     return f"📅 **Stundenplan für {scope}**\n\n"
 
@@ -161,10 +153,9 @@ def days_autocomplete(ctx: AutocompleteContext) -> list[str]:
     """
     Autocompletes filtered days for the timetable argument.
     """
-    default_entries = ["today",
-                       "tomorrow"
-                       ] + [str(n) for n in range(1,
-                                                  MAX_TIMETABLE_RANGE_DAYS)]
+    default_entries = ["today", "tomorrow"] + [
+        str(n) for n in range(1, MAX_TIMETABLE_RANGE_DAYS)
+    ]
 
     return [entry for entry in default_entries if entry.startswith(ctx.value)]
 


### PR DESCRIPTION
The command will now always return stale results for quicker response times and renew the cache in the background after that. This makes the cache-warming service redundant.
Furthermore, since our ever so beloved campus dual sometimes struggles with latency, the timeout was ~~removed entirely~~ increased greatly which should be fine as fetching happens in the background.

Breaking: we loose logging since I didn't feel like overriding the internal methods it uses to debug-log